### PR TITLE
Update SnomedValueSetUtil.java

### DIFF
--- a/src/main/java/org/snomed/cdsservice/util/SnomedValueSetUtil.java
+++ b/src/main/java/org/snomed/cdsservice/util/SnomedValueSetUtil.java
@@ -12,7 +12,7 @@ import java.util.stream.Stream;
 public class SnomedValueSetUtil {
 
 	// Map of characters that will not be URL encoded to help ECL readability
-	private static final Map<String, String> eclDecodeForReadabililtyMap = Stream.of("<", ">", "(", ")", "|", "!")
+	private static final Map<String, String> eclDecodeForReadabililtyMap = Stream.of("<", ">", "(", ")", "|", "!", ":", "=", ",")
 			.collect(Collectors.toMap(s -> URLEncoder.encode(s, StandardCharsets.UTF_8), Function.identity()));
 
 	/**


### PR DESCRIPTION
snowstorm-lite server throws otherwise an error for the % character when those chars are url encoded.